### PR TITLE
Fix signals for post_migrate_create_statuses

### DIFF
--- a/nautobot_bgp_models/signals.py
+++ b/nautobot_bgp_models/signals.py
@@ -1,13 +1,17 @@
 """Nautobot signal handler functions for nautobot_bgp_models."""
 
+from django.apps import apps as global_apps
 from django.conf import settings
 
 PLUGIN_SETTINGS = settings.PLUGINS_CONFIG["nautobot_bgp_models"]
 
 
-def post_migrate_create_statuses(sender, apps, **kwargs):
+def post_migrate_create_statuses(sender, *, apps=global_apps, **kwargs):
     """Callback function for post_migrate() -- create default Statuses."""
     # pylint: disable=invalid-name
+    if not apps:
+        return
+
     Status = apps.get_model("extras", "Status")
 
     for model_name, default_statuses in PLUGIN_SETTINGS.get("default_statuses", {}).items():


### PR DESCRIPTION
This PR fixes post_migrate_create_statuses and by removing positional `apps` attribute.
For cases where `apps` is not a key in provided kwargs, function returns None.

Background:

Django framework defines three places where the post_migrate signal is emitted:

1. flush.py management command : `emit_post_migrate_signal(verbosity, interactive, database)` - lack of APPS attribute
2. Django test cases: `emit_post_migrate_signal(verbosity=0, interactive=False, db=db_name)`
3. migrate.py management command `emit_post_migrate_signal(self.verbosity, self.interactive, connection.alias, apps=post_migrate_apps, plan=plan,)`