### PR TITLE
Disable endpoint ordering in Peering table until fixed

### DIFF
--- a/nautobot_bgp_models/tables.py
+++ b/nautobot_bgp_models/tables.py
@@ -225,6 +225,7 @@ class PeeringTable(StatusTableMixin, BaseTable):
         viewname="plugins:nautobot_bgp_models:peering",
         args=[A("pk")],
         text=str,
+        orderable=False,
     )
 
     endpoint_a = tables.LinkColumn(

--- a/nautobot_bgp_models/tables.py
+++ b/nautobot_bgp_models/tables.py
@@ -228,11 +228,12 @@ class PeeringTable(StatusTableMixin, BaseTable):
     )
 
     endpoint_a = tables.LinkColumn(
-        verbose_name="Endpoint", text=lambda x: str(x.endpoint_a.local_ip) if x.endpoint_a else None
+        verbose_name="Endpoint", text=lambda x: str(x.endpoint_a.local_ip) if x.endpoint_a else None, orderable=False
+
     )
 
     endpoint_z = tables.LinkColumn(
-        verbose_name="Endpoint", text=lambda x: str(x.endpoint_z.local_ip) if x.endpoint_z else None
+        verbose_name="Endpoint", text=lambda x: str(x.endpoint_z.local_ip) if x.endpoint_z else None, orderable=False
     )
     actions = ButtonsColumn(model=models.Peering)
 

--- a/nautobot_bgp_models/tables.py
+++ b/nautobot_bgp_models/tables.py
@@ -230,7 +230,6 @@ class PeeringTable(StatusTableMixin, BaseTable):
 
     endpoint_a = tables.LinkColumn(
         verbose_name="Endpoint", text=lambda x: str(x.endpoint_a.local_ip) if x.endpoint_a else None, orderable=False
-
     )
 
     endpoint_z = tables.LinkColumn(


### PR DESCRIPTION
This PR disables endpoints ordering for the Peering table. It does not provide long-term solution for #113 , but rather prevents the error. 

The filtering and ordering for inherited properties was never supported and was an already known-issue - I added the #115 for tracking separately.

Closes #113 