### PR TITLE
Fix missing status field in BGP Routing Instance form

### DIFF
--- a/nautobot_bgp_models/forms.py
+++ b/nautobot_bgp_models/forms.py
@@ -127,6 +127,7 @@ class BGPRoutingInstanceForm(NautobotModelForm):
         fields = (
             "device",
             "autonomous_system",
+            "status",
             "description",
             "router_id",
             "peergroup_template",

--- a/nautobot_bgp_models/tests/test_forms.py
+++ b/nautobot_bgp_models/tests/test_forms.py
@@ -46,6 +46,48 @@ class AutonomousSystemFormTestCase(TestCase):
         self.assertEqual("This field is required.", form.errors["status"][0])
 
 
+class BGPRoutingInstanceTestCase(TestCase):
+    """Test the BGPRoutingInstance create/edit form."""
+
+    form_class = forms.BGPRoutingInstanceForm
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up class-wide data for the test."""
+        cls.status_active = Status.objects.get(slug="active")
+        cls.status_active.content_types.add(ContentType.objects.get_for_model(models.BGPRoutingInstance))
+        cls.status_active.content_types.add(ContentType.objects.get_for_model(models.AutonomousSystem))
+        manufacturer = Manufacturer.objects.create(name="Cisco", slug="cisco")
+        devicetype = DeviceType.objects.create(manufacturer=manufacturer, model="CSR 1000V", slug="csr1000v")
+        site = Site.objects.create(name="Site 1", slug="site-1")
+        devicerole = DeviceRole.objects.create(name="Router", slug="router", color="ff0000")
+        cls.device = Device.objects.create(
+            device_type=devicetype, device_role=devicerole, name="Device 1", site=site, status=cls.status_active
+        )
+        cls.asn = models.AutonomousSystem.objects.create(asn=4294967291, status=cls.status_active)
+
+    def test_valid_form(self):
+        """Add a device through form."""
+        data = {
+            "autonomous_system": self.asn,
+            "device": self.device,
+            "status": self.status_active,
+            "description": "RI for Device 1",
+        }
+        form = self.form_class(data)
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertTrue(form.save())
+
+        routing_instance = models.BGPRoutingInstance.objects.get(device=self.device)
+        self.assertEqual(routing_instance.device, self.device)
+
+    def test_status_required(self):
+        data = {"autonomous_system": self.asn, "device": self.device}
+        form = self.form_class(data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual("This field is required.", form.errors["status"][0])
+
+
 class PeerGroupFormTestCase(TestCase):
     """Test the PeerGroup create/edit form."""
 


### PR DESCRIPTION
As a result of adding status field to the BGP Routing Instance model, we broken Routing Instance form. This resulted in no ability to add new routing instance through UI

- Fix missing status field in BGP Routing Instance form
- Add unit tests for BGP Routing Instance form

Closes #119 