### PR TITLE
Remove enforcement for ASN's provider

### DIFF
--- a/nautobot_bgp_models/models.py
+++ b/nautobot_bgp_models/models.py
@@ -642,9 +642,9 @@ class PeerEndpoint(PrimaryModel, InheritanceMixin, BGPExtraAttributesMixin):
         if self.routing_instance:
             if local_ip_value not in IPAddress.objects.filter(interface__device_id=self.routing_instance.device.id):
                 raise ValidationError("Peer IP not associated with Routing Instance")
-        else:
-            if not asn_value.provider:
-                raise ValidationError("ASN requires a specified Provider")
+        # Enforce Routing Instance if local IP belongs to the Device
+        elif not self.routing_instance and local_ip_value.interface.exists():
+            raise ValidationError("Must specify Routing Instance for this IP Address")
 
 
 @extras_features(

--- a/nautobot_bgp_models/tests/test_api.py
+++ b/nautobot_bgp_models/tests/test_api.py
@@ -652,18 +652,19 @@ class PeerEndpointAPITestCase(APIViewTestCases.APIViewTestCase):
             autonomous_system=cls.provider_asn,
             peering=cls.peering[0],
         )
+
+        # Peering #3
         models.PeerEndpoint.objects.create(
+            routing_instance=cls.bgp_routing_instance,
             source_ip=cls.addresses[2],
             autonomous_system=cls.provider_asn,
             peering=cls.peering[3],
         )
-        # models.PeerEndpoint.objects.create(
-        #     source_ip=cls.addresses[3],
-        #     autonomous_system=cls.provider_asn,
-        #     peering=cls.peering[3]
-        # )
-
-        # models.PeerEndpoint.objects.create(local_ip=cls.addresses[2], peer_group=peergroup, peering=cls.peering[1])
+        models.PeerEndpoint.objects.create(
+            source_ip=cls.addresses[3],
+            autonomous_system=cls.provider_asn,
+            peering=cls.peering[3],
+        )
 
         cls.create_data = [
             # Peering #1
@@ -676,12 +677,6 @@ class PeerEndpointAPITestCase(APIViewTestCases.APIViewTestCase):
             {
                 "source_ip": cls.addresses[4].pk,
                 "autonomous_system": cls.provider_asn.pk,
-                "peering": cls.peering[1].pk,
-            },
-            {
-                "source_ip": cls.addresses[2].pk,
-                "routing_instance": cls.bgp_routing_instance.pk,
-                "peer_group": peergroup.pk,
                 "peering": cls.peering[1].pk,
             },
         ]


### PR DESCRIPTION
Solves #122 

1) Current implementation supports peerings between devices modelled and non-modelled within nautobot
2) For devices non-modelled in nautobot, user was enforced to specify a Provider for the remote ASN

I propose to loose this as it was proven to be too restrictive. 

This PR removes mandatory `ASN.Provider` and introduces a new check (if the Local IP is associated with the actual Device modelled in Nautobot). For cases where the remote device with its IP address is modelled in Nautobot, a Routing Instance will be mandatory in the peering.