### PR TITLE
Overhaul of peer endpoint's IP

### DIFF
--- a/nautobot_bgp_models/signals.py
+++ b/nautobot_bgp_models/signals.py
@@ -2,6 +2,12 @@
 
 from django.apps import apps as global_apps
 from django.conf import settings
+from django.db import transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from nautobot_bgp_models.models import PeerGroup
+
 
 PLUGIN_SETTINGS = settings.PLUGINS_CONFIG["nautobot_bgp_models"]
 
@@ -29,3 +35,20 @@ def post_migrate_create_statuses(sender, *, apps=global_apps, **kwargs):
             if ct_model not in status.content_types.all():
                 status.content_types.add(ct_model)
                 status.save()
+
+
+@receiver(post_save, sender=PeerGroup)
+def handle_peergroup_updates(instance, created, raw=False, **kwargs):
+    """
+    Update child PeerEndpoints if PeerGroup has changed.
+    This function should especially update all endpoint's IPs to support change
+    of the `peer_group.source_ip` or `peer_group.source_interface`. Change of these attributes impacts
+    effective Peer Endpoints IP addresses as PeerEndpoint might inherit values from the PeerGroup
+    """
+    if raw or created:
+        return
+    with transaction.atomic():
+        for endpoint in instance.endpoints.all():
+            if endpoint.local_ip != endpoint.ip:
+                endpoint.ip = endpoint.local_ip
+                endpoint.save()


### PR DESCRIPTION
- Introduce `ip` attribute on the `PeerEndpoint` model. This attribute should always store the computed endpoint's IP Address.

1. [x] Change of `peer_endpoint.source_ip`
- `source_ip` is set - implemented by `peer_endpoint.save()`
- `source_ip` is removed - implemented by `peer_endpoint.save()`
- `source_ip` is changed - implemented by `peer_endpoint.save()`

2. [x] Change of `peer_group.source_ip`
- `source_ip` set on peergroup - send signal any time this setting changes on the parent peer_group
   this will only impact peer_endpoints if they had `peer_group.source_interface` inheritance before
   **implemented through `handle_peergroup_updates` signal**

- `source_ip` removed on peergroup - send signal any time peer endpoint is added to the peer group
   **implemented through `handle_peergroup_updates` signal**

- `source_ip` changed on the peergroup - send signal any time peer endpoint is removed from the peer group
   **implemented through `handle_peergroup_updates` signal**

**----- 8< NOTES BELOW ARE NOT YET CLEANED --------------- 8< -------**

3. [ ] PeerEndpoint group membership
- peerendpoint added to a `peer_group`
- peerendpoint removed from a `peer_group`

3. [ ] Change of the `peer_endpoint.source_interface`
- Attribute is set
- Attribute is removed
- Attribute is changed

4. [ ] Change of `peer_group.source_interface`
- send signal any time this setting changes on the parent peer_group
- source_interface removed on PG
- source_interface added on PG
- send signal any time peer endpoint is added to the peer group
- send signal any time peer endpoint is removed from the peer group

5. [ ] Change on the interface
- IP address is added to the interface
- IP Address is removed on the interface
- No IP Address on the interface
- Multiple many IP address on the interface

7. [ ] Source interface has many IP addresses:
- many IPv4 addresses
- and many IPv6 addresses on same intf
